### PR TITLE
add pynacl validator endpoint

### DIFF
--- a/drp_aa_mvp/data_rights_request/pynacl_validator.py
+++ b/drp_aa_mvp/data_rights_request/pynacl_validator.py
@@ -3,7 +3,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from nacl.encoding import Base64Encoder
 from nacl.signing import VerifyKey
-import nacl.exceptions 
+import nacl.exceptions
 import json
 from datetime import datetime
 
@@ -39,7 +39,7 @@ def validate_pynacl(request):
       context["valid"] = False
       context["reasons"] += [f"BadSignatureError raised"]
       return render(request, 'data_rights_request/validate_pynacl.html', context)
-        
+
     verified_dict = dict()
     try:
       verified_dict = json.loads(verified_obj)
@@ -102,4 +102,3 @@ def validate_inner_dict(obj: dict, context: dict):
             context["reasons"] += [f"{field} is missing in object"]
 
     return context
-    

--- a/drp_aa_mvp/data_rights_request/pynacl_validator.py
+++ b/drp_aa_mvp/data_rights_request/pynacl_validator.py
@@ -1,0 +1,105 @@
+from django.shortcuts import render
+from django.views.decorators.csrf import csrf_exempt
+
+from nacl.encoding import Base64Encoder
+from nacl.signing import VerifyKey
+import nacl.exceptions 
+import json
+from datetime import datetime
+
+from .models import ACTION_CHOICES, REGIME_CHOICES
+
+VERIFY_KEY_HEADER = "X-DRP-VerifyKey"
+
+@csrf_exempt
+def validate_pynacl(request):
+    '''Validate an application/octet-stream request containing the
+    libsodium signed token with the verify key stuffed in to a header,
+    base64 encoded.
+    '''
+
+    context = dict(valid=True,
+                   reasons=list())
+
+    if VERIFY_KEY_HEADER not in request.headers:
+      context["valid"] = False
+      context["reasons"] += [f"No {VERIFY_KEY_HEADER} in request"]
+      return render(request, 'data_rights_request/validate_pynacl.html', context)
+
+    verify_key = VerifyKey(
+        request.headers.get(VERIFY_KEY_HEADER),
+        encoder=Base64Encoder
+    )
+
+    verified_obj = bytes()
+    try:
+      blob = request.read()
+      verified_obj = verify_key.verify(blob)
+    except nacl.exceptions.BadSignatureError:
+      context["valid"] = False
+      context["reasons"] += [f"BadSignatureError raised"]
+      return render(request, 'data_rights_request/validate_pynacl.html', context)
+        
+    verified_dict = dict()
+    try:
+      verified_dict = json.loads(verified_obj)
+    except json.JSONDecodeError:
+      context["valid"] = False
+      context["reasons"] += [f"JSONDecodeError raised"]
+      return render(request, 'data_rights_request/validate_pynacl.html', context)
+
+    context = validate_inner_dict(verified_dict, context)
+    return render(request, 'data_rights_request/validate_pynacl.html', context)
+
+
+def validate_inner_dict(obj: dict, context: dict):
+    '''validate fields of obj as a verified, deserialized DataRightsRequest
+
+    TODO: shove this in to the 0.6-schema model object and call
+    is_valid() on it, but for now we just check keys exist etc.
+    '''
+    check_fields = ["iss", "aud", "exp", "iat"]
+    for field in check_fields:
+        if field not in obj:
+            context["valid"] = False
+            context["reasons"] += [f"{field} is missing in object"]
+
+    check_datetime_fields = ["exp", "iat"]
+    for field in check_datetime_fields:
+        try:
+            datetime.fromisoformat(obj[field])
+        except ValueError:
+            context["valid"] = False
+            context["reasons"] += [f"{field} is not ISO 8601"]
+
+
+    ver = obj.get("drp.version", None)
+    if ver != "0.6":
+        context["valid"] = False
+        context["reasons"] += [f"DRP version {ver} is not 0.6"]
+
+    right = obj.get("exercise", None)
+    # extract from tuple
+    if right not in [action[1] for action in ACTION_CHOICES]:
+        context["valid"] = False
+        context["reasons"] += [f"{right} not in valid actions"]
+
+    regime = obj.get("regime", None)
+    # extract from tuple
+    if regime not in [regime[1] for regime in REGIME_CHOICES]:
+        context["valid"] = False
+        context["reasons"] += [f"{regime} not valid"]
+
+    shall_claims = ["name", "email", "email_verified"]
+    for field in shall_claims:
+        if field not in obj:
+            context["valid"] = False
+            context["reasons"] += [f"{field} is missing in object"]
+
+    may_claims = ["phone_number", "phone_number_verified", "address", "address_verified", "power_of_attorney"]
+    for field in may_claims:
+        if field not in obj:
+            context["reasons"] += [f"{field} is missing in object"]
+
+    return context
+    

--- a/drp_aa_mvp/data_rights_request/pynacl_validator.py
+++ b/drp_aa_mvp/data_rights_request/pynacl_validator.py
@@ -14,8 +14,18 @@ VERIFY_KEY_HEADER = "X-DRP-VerifyKey"
 @csrf_exempt
 def validate_pynacl(request):
     '''Validate an application/octet-stream request containing the
-    libsodium signed token with the verify key stuffed in to a header,
+    NaCL signed token with the verify key stuffed in to a header,
     base64 encoded.
+
+    This method DOES NOT do a validation sufficient enough to be a
+    drop-in validator for DRP Data Rights Requests and only exists to
+    exhibit the cryptographic signing/verifying flows via PyNaCl. Keys
+    SHOULD NOT be sent in-band in this method as no real trust root is
+    established.
+
+    As the DRP public key directories are designed this code will be
+    iterated upon as a test-bed for this network operating model.
+
     '''
 
     context = dict(valid=True,

--- a/drp_aa_mvp/data_rights_request/pynacl_validator_submit.py
+++ b/drp_aa_mvp/data_rights_request/pynacl_validator_submit.py
@@ -1,0 +1,48 @@
+import os
+import base64
+import json
+from urllib.request import urlopen, Request
+import urllib.error
+from nacl import signing
+from nacl.public import PrivateKey
+
+# Generate a private key and a signing key
+signing_key = signing.SigningKey.generate()
+verify_key = signing_key.verify_key
+
+# Get the public key and signing key bytes
+signing_key_bytes = signing_key.encode()
+verify_key_bytes = verify_key.encode()
+
+# Encode the public key and signing key bytes as base64
+signing_key_b64 = base64.b64encode(signing_key_bytes).decode()
+verify_key_b64 = base64.b64encode(verify_key_bytes).decode()
+
+# Print the signing key
+print(f"Signing key: {signing_key_b64}")
+print(f"Verify key: {verify_key_b64}")
+
+# Create the object to sign
+obj = {
+    "iss": "issuer",
+    "aud": "audience",
+    "exp": "2022-12-31T23:59:59.999999Z",
+    "iat": "2022-12-04T10:14:00Z"
+}
+
+# Sign the object
+signed_obj = signing_key.sign(json.dumps(obj).encode())
+print(signed_obj)
+
+# Submit the signed object to the /validate endpoint
+request = Request("http://localhost:8000/data_rights_request/pynacl_validate", signed_obj)
+request.add_header("content-type", "application/octet-stream")
+request.add_header("X-DRP-VerifyKey", verify_key_b64)
+response = None
+try:
+    response = urlopen(request)
+except urllib.error.HTTPError as e:
+    print(e.read())
+else:
+    # Print the response
+    print(response.read().decode())

--- a/drp_aa_mvp/data_rights_request/pynacl_validator_submit.py
+++ b/drp_aa_mvp/data_rights_request/pynacl_validator_submit.py
@@ -3,46 +3,73 @@ import base64
 import json
 from urllib.request import urlopen, Request
 import urllib.error
+import logging
+
 from nacl import signing
 from nacl.public import PrivateKey
+from nacl.encoding import Base64Encoder
 
-# Generate a private key and a signing key
-signing_key = signing.SigningKey.generate()
-verify_key = signing_key.verify_key
+LOCAL_VALIDATOR_URL = "http://localhost:8000/data_rights_request/pynacl_validate"
 
-# Get the public key and signing key bytes
-signing_key_bytes = signing_key.encode()
-verify_key_bytes = verify_key.encode()
 
-# Encode the public key and signing key bytes as base64
-signing_key_b64 = base64.b64encode(signing_key_bytes).decode()
-verify_key_b64 = base64.b64encode(verify_key_bytes).decode()
+def generate_keys() -> (str, str):
+    '''
+    Returns tuple with signing and verify key
+    '''
+    # Generate a private key and a signing key
+    # these are `bytes' objects
+    signing_key = signing.SigningKey.generate()
+    verify_key = signing_key.verify_key
 
-# Print the signing key
-print(f"Signing key: {signing_key_b64}")
-print(f"Verify key: {verify_key_b64}")
+    return (signing_key, verify_key)
 
-# Create the object to sign
-obj = {
-    "iss": "issuer",
-    "aud": "audience",
-    "exp": "2022-12-31T23:59:59.999999Z",
-    "iat": "2022-12-04T10:14:00Z"
-}
+def make_req(signing_key):
+    '''
+    return a serialized JSON blob signed with the given PyNaCl signing key
+    '''
 
-# Sign the object
-signed_obj = signing_key.sign(json.dumps(obj).encode())
-print(signed_obj)
+    # Create the object to sign
+    obj = {
+        "iss": "issuer",
+        "aud": "audience",
+        "exp": "2022-12-31T23:59:59.999999Z",
+        "iat": "2022-12-04T10:14:00Z"
+    }
 
-# Submit the signed object to the /validate endpoint
-request = Request("http://localhost:8000/data_rights_request/pynacl_validate", signed_obj)
-request.add_header("content-type", "application/octet-stream")
-request.add_header("X-DRP-VerifyKey", verify_key_b64)
-response = None
-try:
-    response = urlopen(request)
-except urllib.error.HTTPError as e:
-    print(e.read())
-else:
-    # Print the response
-    print(response.read().decode())
+    # Sign the object
+    signed_obj = signing_key.sign(json.dumps(obj).encode())
+
+    print(signed_obj)
+    return signed_obj
+
+def submit_signed_request(validator_url):
+    signing_key, verify_key = generate_keys()
+
+    # Get the public key and signing key as b64 strings
+    signing_key_b64 = signing_key.encode(encoder=Base64Encoder)
+    verify_key_b64 = verify_key.encode(encoder=Base64Encoder)
+
+    # Print the signing key
+    print(f"Signing key: {signing_key_b64}")
+    print(f"Verify key: {verify_key_b64}")
+
+    signed_obj = make_req(signing_key)
+
+    # Submit the signed object to the /validate endpoint
+    request = Request(validator_url, signed_obj)
+    request.add_header("content-type", "application/octet-stream")
+    # smuggle DRP verify key in-band. This is NOT sufficient for production security!
+    request.add_header("X-DRP-VerifyKey", verify_key_b64)
+
+    try:
+        response = urlopen(request)
+    except urllib.error.HTTPError as e:
+        resp = e.read()
+    else:
+        resp = response.read().decode()
+
+    return resp
+
+if __name__ == "__main__":
+    print("Running...")
+    print(submit_signed_request(LOCAL_VALIDATOR_URL))

--- a/drp_aa_mvp/data_rights_request/templates/data_rights_request/validate_pynacl.html
+++ b/drp_aa_mvp/data_rights_request/templates/data_rights_request/validate_pynacl.html
@@ -1,0 +1,18 @@
+<br/>
+<h2>OSIRAA - Open Source Implementer's Reference Authorized Agent</h2>
+
+<h3>Validate AA-submitted libsodium blob</h3>
+<br/>
+
+<p>
+  Request is valid? <b>{{ valid }}</b>
+
+  <ul>
+  {% for reason in reasons %}
+  <li>
+    {{ reason }}
+  </li>
+  {% endfor %}
+  </ul>
+</p>
+

--- a/drp_aa_mvp/data_rights_request/urls.py
+++ b/drp_aa_mvp/data_rights_request/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 from . import views
+from . import pynacl_validator
 
 
 urlpatterns = [
@@ -23,5 +24,7 @@ urlpatterns = [
     #path('request_sent', views.request_sent, name='request_sent'),
 
     path('data_rights_request_sent_return', views.data_rights_request_sent_return, 
-        name='data_rights_request_sent_return')
+         name='data_rights_request_sent_return'),
+
+    path('pynacl_validate', pynacl_validator.validate_pynacl, name='validate_pynacl'),
 ]

--- a/drp_aa_mvp/data_rights_request/views.py
+++ b/drp_aa_mvp/data_rights_request/views.py
@@ -452,7 +452,7 @@ def post_exercise_rights(request_url, bearer_token, request_json):
     -H 'Authorization: Bearer eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..Y2pZOkoc445kyqOZAKGjzw.-scnX7wxH2MeTohuCPPThCUFp7qUoyRA2hJlOsSUix6RmYRT2uz2sPUZnT-07-jYz3-32G07aIEyk30JeoHHsg3SMUa7V8Y2OlBI0WMaZ3QUscEuVZa7s3RuVVfvtePD195MMmH5w3RQkgxMrP8Lj8KubiYnRYw2n_rVt0crtP75s0NSnIF2ThWCAiq5gaGAdYSjzHwMWi9OAZekEuxNmFaTa2tu_j9Hi8uLbvjsp9-z5IjmGGsiTPNbPj5JgCWOxy-E-Ub6KMWMcCIxoLAki_Qfo5d1JwffvDQsEJT4zefm3HSdpFphv579KpgStLVhIh4r_5OnLl-w-ueHfDO3iCMgw8KIw7p5GtiXWggCejhJCohcM_g2msfG9OFeMd-7vLiFUuk4d4dzIbXXdOHGcv-lL3EyQUnRzQRXVGV3wHnxvN3Xyli4YQUqCk_qkJ1yf8LSJejqTklaCwovwuMWEu6ZwrXVq9OorMphHtnoRW-Ngw4oYa8SIME0YF3vdchCaglbNDhMVVjFkUkKsNBHfqUiZWLyXlNCluhQpMKORW5Uqk0mLtgLX_U5BlkibjcR9440UZvZoT_LBpiT21nLLtCdidHfW7bEgH9-bBMtoEwBeBM_RmxT1ysRKrdJ0NZCZgyU3FMijV-XFmIt2aZDaD2fnDJDBP1q0Aw1tVfucESZJHKUQtVKp6Q.EMaYOKnSqk2ApwP-uss3CA'
     """
 
-    request_headers = {'Authorization': "Bearer {bearer_token}"}
+    request_headers = {'Authorization': f"Bearer {bearer_token}"}
 
     response = requests.post(request_url, json=request_json, headers=request_headers)
 

--- a/drp_aa_mvp/requirements.txt
+++ b/drp_aa_mvp/requirements.txt
@@ -92,3 +92,4 @@ Werkzeug==2.0.1
 whitenoise==5.3.0
 woopra==0.3.2
 woopra-tracker==0.3
+PyNaCl==1.5.0


### PR DESCRIPTION
This code show how to submit and validate DRP data rights requests with pynacl. 

0.7 specified implementations will use static signing/verify keys exchanged out of band but for purposes of being able to do this statelessly the verify key is smuggled in-band in the `X-DRP-VerifyKey` http header

`docker-compose exec web python /code/data_rights_request/pynacl_validator_submit.py` or virtualenv equivalent call will submit a request against a server running on localhost:8000:

```
[nix-shell:~/Code/osiraa]$ docker-compose exec web python /code/data_rights_request/pynacl_validator_submit.py
Signing key: +BMO1LpDq66PHoB+P8U1bnk/iLqUJKLmIcBcisyaMcY=
Verify key: zwINAujec6D3b3okhOgz+DWIkuH4BSw+V2S+IyyoPFI=
b'\xd4\x96\xdc\xd6\x0fN\xadR\xe3\xec\xb8*\xd6\xc2#U#R8\xfa\xb6u\x1a!\x909k\xbf.1\x9f\x13uTDq\x9f@o\xe8\xb3\xdf\x17\xa0\xf0\xe8\x11\xb0CKV\xf5)\x0e\x98 O\xadq\xc2\x96\x8d5\n{"iss": "issuer", "aud": "audience", "exp": "2022-12-31T23:59:59.999999Z", "iat": "2022-12-04T10:14:00Z"}'
<br/>
<h2>OSIRAA - Open Source Implementer's Reference Authorized Agent</h2>

<h3>Validate AA-submitted libsodium blob</h3>
<br/>

<p>
  Request is valid? <b>False</b>

  <ul>
  
  <li>
    exp is not ISO 8601
  </li>
  
  <li>
    iat is not ISO 8601
  </li>
  
  <li>
    DRP version None is not 0.6
  </li>
  
  <li>
    None not in valid actions
  </li>
  
  <li>
    None not valid
  </li>
  
  <li>
    name is missing in object
  </li>
  
  <li>
    email is missing in object
  </li>
  
  <li>
    email_verified is missing in object
  </li>
  
  <li>
    phone_number is missing in object
  </li>
  
  <li>
    phone_number_verified is missing in object
  </li>
  
  <li>
    address is missing in object
  </li>
  
  <li>
    address_verified is missing in object
  </li>
  
  <li>
    power_of_attorney is missing in object
  </li>
  
  </ul>
</p>
```