### PR TITLE
add Authorization test for Discovery endpoint

### DIFF
--- a/drp_aa_mvp/data_rights_request/views.py
+++ b/drp_aa_mvp/data_rights_request/views.py
@@ -249,10 +249,14 @@ def set_covered_biz_well_known_params(covered_biz, response):
         print('**  WARNING - set_covered_biz_well_known_params(): NOT valid json  **')
         return False  
           
-    reponse_json = response.json()
-    covered_biz.api_root = reponse_json['api_base']
-    covered_biz.supported_actions = reponse_json['actions']
-    covered_biz.save()
+    try:
+        reponse_json = response.json()
+        covered_biz.api_root = reponse_json['api_base']
+        covered_biz.supported_actions = reponse_json['actions']
+        covered_biz.save()
+    except KeyError as e:
+        print('**  WARNING - set_covered_biz_well_known_params(): missing keys **')
+        return False
 
 
 def get_covered_biz_form_display(covered_businesses, selected_biz):

--- a/drp_aa_mvp/data_rights_request/views.py
+++ b/drp_aa_mvp/data_rights_request/views.py
@@ -53,11 +53,16 @@ def send_request_discover_data_rights(request):
     covered_biz_id  = request.POST.get('sel_covered_biz_id')
     covered_biz     = CoveredBusiness.objects.get(pk=covered_biz_id)
     request_url     = covered_biz.discovery_endpoint  # + ".well-known/data-rights.json"
+    bearer_token    = covered_biz.auth_bearer_token or ""
 
     if (validators.url(request_url)):
-        response = get_well_known(request_url)   
+        unauthed_response = get_well_known(request_url)
+        response = get_well_known(request_url, bearer_token)
         set_covered_biz_well_known_params(covered_biz, response)
-        discover_test_results = test_discovery_endpoint(request_url, response)
+        discover_test_results = test_discovery_endpoint(request_url, {
+            'unauthed': unauthed_response,
+            'authed': response
+        })
 
         request_sent_context = { 
             'covered_biz':      covered_biz,
@@ -428,8 +433,12 @@ def get_request_id (covered_biz, user_identity):
 #-------------------------------------------------------------------------------------------------#
 
 #GET /.well-known/data-rights.json
-def get_well_known(discovery_url):
-    response = requests.get(discovery_url)
+def get_well_known(discovery_url, bearer_token=""):
+    if bearer_token != "":
+        request_headers = {'Authorization': f"Bearer {bearer_token}"}
+        response = requests.get(discovery_url, headers=request_headers)
+    else:
+        response = requests.get(discovery_url)
 
     """
     {

--- a/drp_aa_mvp/reporting/views.py
+++ b/drp_aa_mvp/reporting/views.py
@@ -36,7 +36,7 @@ def test_contains_version_field(response):
         return False 
     return 'version' in response_json and response_json['version'] == '0.5'  
 
-def test_contians_api_base(response):
+def test_contains_api_base(response):
     try:
         response_json = json.loads(response.text)
     except ValueError as e:
@@ -125,8 +125,8 @@ def test_discovery_endpoint(request_url, response):
     test_results.append({'name': 'Contains version field', 'result': contains_version_field})
 
     # test Discovery Endpoint MUST provide an API base
-    contians_api_base = test_contians_api_base(response)
-    test_results.append({'name': 'Contains API Base', 'result': contians_api_base})
+    contains_api_base = test_contains_api_base(response)
+    test_results.append({'name': 'Contains API Base', 'result': contains_api_base})
 
     # test API base MUST be valid for subsequent calls
     is_valid_api_base = test_is_valid_api_base(response)

--- a/drp_aa_mvp/reporting/views.py
+++ b/drp_aa_mvp/reporting/views.py
@@ -91,9 +91,7 @@ def test_discovery_contains_no_unknown_fields(response):
     return True
 
 
-def test_discovery_endpoint(request_url, response):
-    test_results = []
-
+def test_discovery_endpoint(request_url, responses):
     """
     1.  GET .well-known/data-rights.json
         - Covered Business's domain SHOULD have a /.well-known/data-rights.json
@@ -107,6 +105,21 @@ def test_discovery_endpoint(request_url, response):
         - Discovery Endpoint MAY contain a user_relationships hint set
         - Discovery Endpoint SHOULD NOT contain additional undefined fields
     """
+    test_results = []
+
+    # unauthed response SHOULD be a 200 response code
+    unauthed = responses['unauthed']
+    authed = responses['authed']
+
+    is_endpoint_auth_not_required = unauthed.status_code == 200
+    test_results.append({'name': 'Endpoint auth is not required', 'result': is_endpoint_auth_not_required})
+
+    if is_endpoint_auth_not_required:
+        # request sent without authorization headers
+        response = unauthed
+    else:
+        # request sent with authorization headers
+        response = authed
 
     # test Covered Business's domain SHOULD have a discovery endpoint
     is_valid_endpoint = test_is_discovery_endpoint_valid_url(request_url, response)


### PR DESCRIPTION
Designed this to record a `test_result` for whether the discovery endpoint requires auth:

> Test Results:

> Endpoint auth is not required:False
Is valid enpoint:True
Is compliant enpoint:False
Is valid json:True
Contains version field:False
Contains API Base:False
Is valid API Base:Unknown
Enumerates supported actions:False
Supported actions are valid:True
Supported actions are implemented:Unknown
Contains user relationships:False
Contains no unknown fields:False