### PR TITLE
Fix property name

### DIFF
--- a/drp_aa_mvp/data_rights_request/models.py
+++ b/drp_aa_mvp/data_rights_request/models.py
@@ -168,7 +168,7 @@ class DataRightsRequest(models.Model):
     identity            = models.ForeignKey(IdentityPayload, null=True, on_delete=models.CASCADE)  
 
     def __str__(self):
-        return f"{self.request_id} asking {self.exercise} for {self.identity}"
+        return f"{self.request_id} asking {self.right} for {self.identity}"
 
 
 class DataRightsStatus(models.Model):


### PR DESCRIPTION
Hello guys, 
I was trying osiraa but getting 

```
AttributeError at /admin/drp_pip/datarightsrequest/                                                                      
'DataRightsRequest' object has no attribute 'exercise'                    

```

I'm not a python developer but bit a bit I discovered that perhaps we have here a not aligned refactored part

once changed locally I can list my new freshly dr-requests using admin tool
